### PR TITLE
Fix publishing to Shipyard registry

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,9 +2,10 @@
 name: Publish
 
 on:  # yamllint disable-line rule:truthy
-  push:
-    tags:
-      - "v*.*.*"
+  # push:
+  #   tags:
+  #     - "v*.*.*"
+  - push
 
 jobs:
   shipyard:
@@ -32,6 +33,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-22.04
+    if: false
     steps:
       - uses: actions/checkout@v4
       - uses: softprops/action-gh-release@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,10 +2,9 @@
 name: Publish
 
 on:  # yamllint disable-line rule:truthy
-  # push:
-  #   tags:
-  #     - "v*.*.*"
-  - push
+  push:
+    tags:
+      - "v*.*.*"
 
 jobs:
   shipyard:
@@ -34,7 +33,6 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-22.04
-    if: false
     steps:
       - uses: actions/checkout@v4
       - uses: softprops/action-gh-release@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,8 @@ jobs:
 
       - name: Login to shipyard.rs
         run: cargo login --registry wafflehacks ${{ secrets.SHIPYARD_TOKEN }}
+        env:
+          CARGO_NET_GIT_FETCH_WITH_CLI: "true"
 
       - run: cargo publish
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,11 +15,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
 
-      - name: Setup shipyard.rs crate index access over SSH
-        run: |
-          eval $(ssh-agent -s)
-          ssh-add - <<< '${{ secrets.SHIPYARD_SSH_KEY }}'
+      - uses: webfactory/ssh-agent@v0.8.0
+        with:
+          ssh-private-key: ${{ secrets.SHIPYARD_SSH_KEY }}
 
+      - name: Add shipyard host key to .ssh/known_hosts
+        run: |
           mkdir -p ~/.ssh && touch ~/.ssh/known_hosts
           ssh-keyscan ssh.shipyard.rs >> ~/.ssh/known_hosts
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -803,7 +803,7 @@ checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
 
 [[package]]
 name = "migrator"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "migrator"
 description = "A simple library for managing database migrations"
-version = "0.1.1"
+version = "0.1.2"
 license = "MIT"
 homepage = "https://github.com/TheHackerApp/migrator"
 repository = "https://github.com/TheHackerApp/migrator.git"


### PR DESCRIPTION
Explicitly uses the `git` CLI to fetch the crate index via [`CARGO_NET_GIT_FETCH_WITH_CLI`](https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli) and migrates to [`webfactory/ssh-agent`](https://github.com/webfactory/ssh-agent) for adding the SSH key to the agent to authenticate with the registry.

Also bumps the version to `0.1.2`.