### PR TITLE
Use shared logging crate

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: TheHackerApp/setup-rust@main
+        with:
+          ssh-private-key: ${{ secrets.SHIPYARD_SSH_KEY }}
+          token: ${{ secrets.SHIPYARD_TOKEN }}
 
       - run: cargo build --release --lib
 
@@ -19,7 +22,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: TheHackerApp/setup-rust@main
+        with:
+          ssh-private-key: ${{ secrets.SHIPYARD_SSH_KEY }}
+          token: ${{ secrets.SHIPYARD_TOKEN }}
 
       - run: cargo build --release --bin migrate -F cli
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,10 +19,12 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: TheHackerApp/setup-rust@main
         with:
           components: rustfmt
+          ssh-private-key: ${{ secrets.SHIPYARD_SSH_KEY }}
+          token: ${{ secrets.SHIPYARD_TOKEN }}
+
       - run: cargo fmt --all --check
 
   clippy:
@@ -30,9 +32,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: TheHackerApp/setup-rust@main
         with:
           components: clippy
+          ssh-private-key: ${{ secrets.SHIPYARD_SSH_KEY }}
+          token: ${{ secrets.SHIPYARD_TOKEN }}
 
       - run: cargo clippy --all-features -- -D warnings

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,21 +12,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-
-      - uses: webfactory/ssh-agent@v0.8.0
+      - uses: TheHackerApp/setup-rust@main
         with:
           ssh-private-key: ${{ secrets.SHIPYARD_SSH_KEY }}
-
-      - name: Add shipyard host key to .ssh/known_hosts
-        run: |
-          mkdir -p ~/.ssh && touch ~/.ssh/known_hosts
-          ssh-keyscan ssh.shipyard.rs >> ~/.ssh/known_hosts
-
-      - name: Login to shipyard.rs
-        run: cargo login --registry wafflehacks ${{ secrets.SHIPYARD_TOKEN }}
-        env:
-          CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+          token: ${{ secrets.SHIPYARD_TOKEN }}
 
       - run: cargo publish
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -778,6 +778,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
+name = "logging"
+version = "0.1.1"
+source = "registry+ssh://git@ssh.shipyard.rs/wafflehacks/crate-index.git"
+checksum = "b7fe2e0cf5094be981ffa92b51ddff0a3209766bc14185c845807a3b27568d27"
+dependencies = [
+ "eyre",
+ "tracing",
+ "tracing-error",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -811,11 +823,10 @@ dependencies = [
  "dotenvy",
  "eyre",
  "hex",
+ "logging",
  "sqlx",
  "tokio",
  "tracing",
- "tracing-error",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -815,7 +815,7 @@ checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
 
 [[package]]
 name = "migrator"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,11 +21,10 @@ color-eyre = { version = "0.6", optional = true }
 dotenvy = { version = "0.15", optional = true }
 eyre = { version = "0.6", optional = true }
 hex = "0.4"
+logging = { version = "0.1", registry = "wafflehacks", optional = true }
 sqlx = { version = "0.7", default-features = false, features = ["migrate", "postgres", "runtime-tokio", "tls-rustls"] }
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"], optional = true }
 tracing = "0.1"
-tracing-error = { version = "0.2", optional = true }
-tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }
 
 [features]
-cli = ["clap", "color-eyre", "dotenvy", "eyre", "tokio", "tracing-error", "tracing-subscriber"]
+cli = ["clap", "color-eyre", "dotenvy", "eyre", "logging", "tokio"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "migrator"
 description = "A simple library for managing database migrations"
-version = "0.1.2"
+version = "0.1.3"
 license = "MIT"
 homepage = "https://github.com/TheHackerApp/migrator"
 repository = "https://github.com/TheHackerApp/migrator.git"

--- a/src/bin/migrate.rs
+++ b/src/bin/migrate.rs
@@ -7,8 +7,6 @@ use sqlx::{
 };
 use std::{path::PathBuf, str::FromStr};
 use tracing::{info, instrument, log::LevelFilter, Level};
-use tracing_error::ErrorLayer;
-use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Registry};
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
@@ -16,7 +14,9 @@ async fn main() -> eyre::Result<()> {
     dotenv()?;
 
     let config = Config::parse();
-    initialize_logging(config.log_level);
+    logging::config()
+        .default_directive(config.log_level)
+        .init()?;
 
     let migrator = Migrator::new(config.source)
         .await
@@ -69,22 +69,4 @@ async fn connect_to_database(url: &str) -> eyre::Result<PgPool> {
 
     info!("database connected");
     Ok(db)
-}
-
-/// Setup logging and error reporting
-fn initialize_logging(default_level: Level) {
-    Registry::default()
-        .with(
-            EnvFilter::builder()
-                .with_default_directive(default_level.into())
-                .from_env_lossy(),
-        )
-        .with(
-            tracing_subscriber::fmt::layer()
-                .with_file(true)
-                .with_line_number(true)
-                .with_target(true),
-        )
-        .with(ErrorLayer::default())
-        .init();
 }


### PR DESCRIPTION
Uses the internal [`logging`][logging] crate instead of manually implementing it. Also bumps the patch version to `0.1.3`.

[logging]: https://github.com/TheHackerApp/logging