### PR TITLE
Accept source path as argument to adding migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -815,7 +815,7 @@ checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
 
 [[package]]
 name = "migrator"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "migrator"
 description = "A simple library for managing database migrations"
-version = "0.1.3"
+version = "0.2.0"
 license = "MIT"
 homepage = "https://github.com/TheHackerApp/migrator"
 repository = "https://github.com/TheHackerApp/migrator.git"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,15 +19,10 @@ use error::Result;
 
 /// Create a new migration
 #[instrument]
-pub fn add(name: &str) -> Result<()> {
-    let migrations = {
-        let base = Path::new(env!("CARGO_MANIFEST_DIR"));
-        base.join("migrations")
-    };
-
+pub fn add(source: &Path, name: &str) -> Result<()> {
     let name = name.replace(' ', "_");
-    create_file(&migrations, &name, MigrationType::ReversibleUp)?;
-    create_file(&migrations, &name, MigrationType::ReversibleDown)?;
+    create_file(source, &name, MigrationType::ReversibleUp)?;
+    create_file(source, &name, MigrationType::ReversibleDown)?;
 
     Ok(())
 }


### PR DESCRIPTION
Adds a `source` parameter to the `add` method instead of trying to auto-determine the migrations path. Also bumps the minor version to `0.2.0` as a result.